### PR TITLE
Add description for redis in 'heroku help'

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,3 +7,8 @@ exports.commands = [
   require('./lib/commands/redis/timeout'),
   require('./lib/commands/redis/maxmemory')
 ];
+
+exports.topic = {
+  name: 'redis',
+  description: 'manage heroku redis instances'
+}


### PR DESCRIPTION
It looked weird that it was the only entry in `heroku help` to not have a description.