### PR TITLE
Update heroku-cli-util

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "standard"
   },
   "dependencies": {
-    "heroku-cli-util": "5.6.3",
+    "heroku-cli-util": "5.10.10",
     "heroku-client": "2.4.0",
     "ioredis": "1.9.0",
     "ssh2": "0.4.11"


### PR DESCRIPTION
The older version has an issue where it displays WARNING twice for some warnings.

Before:

```console
maciek@mothra:~/code/aux/heroku-redis-jsplugin$ h redis:cli --app pure-stream-89694
 ▸    WARNING: WARNING: Insecure action.
 ▸    All data, including the Redis password, will not be encrypted.
 ▸    WARNING: To proceed, type pure-stream-89694 or re-run this command with --confirm pure-stream-89694
```

After:

```console
maciek@mothra:~/code/aux/heroku-redis-jsplugin$ h redis:cli --app pure-stream-89694
 ▸    WARNING: Insecure action.
 ▸    All data, including the Redis password, will not be encrypted.
 ▸    To proceed, type pure-stream-89694 or re-run this command with --confirm pure-stream-89694
```