### PR TITLE
Heroku cli util upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.nyc_output

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 sudo: false
 node_js:
-  - "iojs"
-  - "5"
+  - "6.2.0"
 notifications:
   email: false

--- a/lib/commands/redis/cli.js
+++ b/lib/commands/redis/cli.js
@@ -174,7 +174,7 @@ module.exports = {
     let vars = {}
     addon.config_vars.forEach(function (key) { vars[key] = config[key] })
 
-    console.log(`Connecting to ${addon.name} (${addon.config_vars.join(', ')}):`)
+    cli.log(`Connecting to ${addon.name} (${addon.config_vars.join(', ')}):`)
     maybeTunnel(redis, vars)
   })
 }

--- a/lib/commands/redis/cli.js
+++ b/lib/commands/redis/cli.js
@@ -1,4 +1,6 @@
 'use strict'
+
+let co = require('co')
 let api = require('./shared.js')
 let cli = require('heroku-cli-util')
 let net = require('net')
@@ -148,9 +150,9 @@ module.exports = {
   description: 'opens a redis prompt',
   args: [{name: 'database', optional: true}],
   flags: [{name: 'confirm', char: 'c', hasValue: true}],
-  run: cli.command({preauth: true}, function * (context, heroku) {
+  run: cli.command({preauth: true}, co.wrap(function * (context, heroku) {
     let addonsFilter = api.make_addons_filter(context.args.database)
-    let addonsList = heroku.apps(context.app).addons().listByApp()
+    let addonsList = heroku.get(`/apps/${context.app}/addons`)
     let addons = addonsFilter(yield addonsList)
     if (addons.length === 0) {
       cli.error('No Redis instances found.')
@@ -161,7 +163,7 @@ module.exports = {
       process.exit(1)
     }
 
-    let config = yield heroku.apps(context.app).configVars().info()
+    let config = yield heroku.get(`/apps/${context.app}/config-vars`)
 
     let addon = addons[0]
     let redis = yield api.request(context, `/redis/v0/databases/${addon.name}`)
@@ -176,5 +178,5 @@ module.exports = {
 
     cli.log(`Connecting to ${addon.name} (${addon.config_vars.join(', ')}):`)
     maybeTunnel(redis, vars)
-  })
+  }))
 }

--- a/lib/commands/redis/cli.js
+++ b/lib/commands/redis/cli.js
@@ -151,21 +151,10 @@ module.exports = {
   args: [{name: 'database', optional: true}],
   flags: [{name: 'confirm', char: 'c', hasValue: true}],
   run: cli.command({preauth: true}, co.wrap(function * (context, heroku) {
-    let addonsFilter = api.make_addons_filter(context.args.database)
-    let addonsList = heroku.get(`/apps/${context.app}/addons`)
-    let addons = addonsFilter(yield addonsList)
-    if (addons.length === 0) {
-      cli.error('No Redis instances found.')
-      process.exit(1)
-    } else if (addons.length > 1) {
-      let names = addons.map(function (addon) { return addon.name })
-      cli.error(`Please specify a single instance. Found: ${names.join(', ')}`)
-      process.exit(1)
-    }
+    let addon = yield api.getRedisAddon(context, heroku)
 
     let config = yield heroku.get(`/apps/${context.app}/config-vars`)
 
-    let addon = addons[0]
     let redis = yield api.request(context, `/redis/v0/databases/${addon.name}`)
     let hobby = redis.plan.indexOf('hobby') === 0
 

--- a/lib/commands/redis/credentials.js
+++ b/lib/commands/redis/credentials.js
@@ -1,4 +1,6 @@
 'use strict'
+
+let co = require('co')
 let cli = require('heroku-cli-util')
 let api = require('./shared.js')
 
@@ -10,9 +12,9 @@ module.exports = {
   args: [{name: 'database', optional: true}],
   flags: [{name: 'reset', description: 'reset credentials'}],
   description: 'display credentials information',
-  run: cli.command(function * (context, heroku) {
+  run: cli.command(co.wrap(function * (context, heroku) {
     let addonsFilter = api.make_addons_filter(context.args.database)
-    let addons = addonsFilter(yield heroku.apps(context.app).addons().listByApp())
+    let addons = addonsFilter(yield heroku.get(`/apps/${context.app}/addons`))
     if (addons.length === 0) {
       cli.error('No Redis instances found.')
       process.exit(1)
@@ -34,5 +36,5 @@ module.exports = {
         cli.log(redis.resource_url)
       }
     }
-  })
+  }))
 }

--- a/lib/commands/redis/credentials.js
+++ b/lib/commands/redis/credentials.js
@@ -13,28 +13,14 @@ module.exports = {
   flags: [{name: 'reset', description: 'reset credentials'}],
   description: 'display credentials information',
   run: cli.command(co.wrap(function * (context, heroku) {
-    let addonsFilter = api.make_addons_filter(context.args.database)
-    let addons = addonsFilter(yield heroku.get(`/apps/${context.app}/addons`))
-    if (addons.length === 0) {
-      cli.error('No Redis instances found.')
-      process.exit(1)
-    } else if (addons.length > 1) {
-      let names = addons.map(function (addon) { return addon.name })
-      cli.error(`Please specify a single instance. Found: ${names.join(', ')}`)
-      process.exit(1)
-    }
-    let addon = addons[0]
+    let addon = yield api.getRedisAddon(context, heroku)
+
     if (context.flags.reset) {
       cli.log(`Resetting credentials for ${addon.name}`)
       yield api.request(context, `/redis/v0/databases/${addon.name}/credentials_rotation`, 'POST')
     } else {
       let redis = yield api.request(context, `/redis/v0/databases/${addon.name}`)
-      if (addons.length === 0) {
-        cli.error('No Redis instances found.')
-        process.exit(1)
-      } else {
-        cli.log(redis.resource_url)
-      }
+      cli.log(redis.resource_url)
     }
   }))
 }

--- a/lib/commands/redis/credentials.js
+++ b/lib/commands/redis/credentials.js
@@ -23,7 +23,7 @@ module.exports = {
     }
     let addon = addons[0]
     if (context.flags.reset) {
-      console.log(`Resetting credentials for ${addon.name}`)
+      cli.log(`Resetting credentials for ${addon.name}`)
       yield api.request(context, `/redis/v0/databases/${addon.name}/credentials_rotation`, 'POST')
     } else {
       let redis = yield api.request(context, `/redis/v0/databases/${addon.name}`)
@@ -31,7 +31,7 @@ module.exports = {
         cli.error('No Redis instances found.')
         process.exit(1)
       } else {
-        console.log(redis.resource_url)
+        cli.log(redis.resource_url)
       }
     }
   })

--- a/lib/commands/redis/info.js
+++ b/lib/commands/redis/info.js
@@ -1,4 +1,6 @@
 'use strict'
+
+let co = require('co')
 let api = require('./shared.js')
 let cli = require('heroku-cli-util')
 
@@ -10,8 +12,8 @@ module.exports = {
   default: true,
   args: [{name: 'database', optional: true}],
   description: 'gets information about redis',
-  run: cli.command(function * (context, heroku) {
-    let addons = yield heroku.apps(context.app).addons().listByApp()
+  run: cli.command(co.wrap(function * (context, heroku) {
+    let addons = yield heroku.get(`/apps/${context.app}/addons`)
     // filter out non-redis addons
     addons = api.make_addons_filter(context.args.database)(addons)
     // get info for each db
@@ -39,5 +41,5 @@ module.exports = {
         return memo
       }, {}), db.redis.info.map(function (row) { return row.name }))
     }
-  })
+  }))
 }

--- a/lib/commands/redis/maintenance.js
+++ b/lib/commands/redis/maintenance.js
@@ -18,27 +18,15 @@ module.exports = {
   description: 'manage maintenance windows',
   help: 'Set or change the maintenance window for your Redis instance',
   run: cli.command(co.wrap(function * (context, heroku) {
-    let addonsFilter = api.make_addons_filter(context.args.database)
-    let addons = addonsFilter(yield heroku.get(`/apps/${context.app}/addons`))
-    if (addons.length === 0) {
-      cli.error('No redis databases found')
-      process.exit(1)
-    } else if (addons.length > 1) {
-      let names = addons.map(function (addon) { return addon.names })
-      cli.error(`Please specify a single instance. Found: ${names.join(', ')}`)
-      process.exit(1)
-    }
-    let addon = addons[0]
+    let addon = yield api.getRedisAddon(context, heroku)
 
     if (addon.plan.name.match(/hobby/) != null) {
-      cli.error('redis:maintenance is not available for hobby-dev instances')
-      process.exit(1)
+      cli.exit(1, 'redis:maintenance is not available for hobby-dev instances')
     }
 
     if (context.flags.window) {
       if (context.flags.window.match(/[A-Za-z]{3,10} \d\d?:[03]0/) == null) {
-        cli.error('Maintenance windows must be "Day HH:MM", where MM is 00 or 30.')
-        process.exit(1)
+        cli.exit(1, 'Maintenance windows must be "Day HH:MM", where MM is 00 or 30.')
       }
 
       let maintenance = yield api.request(context, `/client/v11/databases/${addon.name}/maintenance_window`, 'PUT', { description: context.flags.window })
@@ -49,8 +37,7 @@ module.exports = {
     if (context.flags.run) {
       let app = yield heroku.get(`/apps/${context.app}`)
       if (!app.maintenance && !context.flags.force) {
-        cli.error('Application must be in maintenance mode or --force flag must be used')
-        process.exit(1)
+        cli.exit(1, 'Application must be in maintenance mode or --force flag must be used')
       }
 
       let maintenance = yield api.request(context, `/client/v11/databases/${addon.name}/maintenance`, 'POST')

--- a/lib/commands/redis/maintenance.js
+++ b/lib/commands/redis/maintenance.js
@@ -57,6 +57,6 @@ module.exports = {
     }
 
     let maintenance = yield api.request(context, `/client/v11/databases/${addon.name}/maintenance`, 'GET', null)
-    console.log(maintenance.message)
+    cli.log(maintenance.message)
   })
 }

--- a/lib/commands/redis/maintenance.js
+++ b/lib/commands/redis/maintenance.js
@@ -1,4 +1,6 @@
 'use strict'
+
+let co = require('co')
 let cli = require('heroku-cli-util')
 let api = require('./shared.js')
 
@@ -15,9 +17,9 @@ module.exports = {
   ],
   description: 'manage maintenance windows',
   help: 'Set or change the maintenance window for your Redis instance',
-  run: cli.command(function * (context, heroku) {
+  run: cli.command(co.wrap(function * (context, heroku) {
     let addonsFilter = api.make_addons_filter(context.args.database)
-    let addons = addonsFilter(yield heroku.apps(context.app).addons().listByApp())
+    let addons = addonsFilter(yield heroku.get(`/apps/${context.app}/addons`))
     if (addons.length === 0) {
       cli.error('No redis databases found')
       process.exit(1)
@@ -40,23 +42,23 @@ module.exports = {
       }
 
       let maintenance = yield api.request(context, `/client/v11/databases/${addon.name}/maintenance_window`, 'PUT', { description: context.flags.window })
-      console.log(`Maintenance window for ${addon.name} (${addon.config_vars.join(', ')}) set to ${maintenance.window}.`)
-      process.exit(0)
+      cli.log(`Maintenance window for ${addon.name} (${addon.config_vars.join(', ')}) set to ${maintenance.window}.`)
+      cli.exit(0)
     }
 
     if (context.flags.run) {
-      let app = yield heroku.apps(context.app).info()
+      let app = yield heroku.get(`/apps/${context.app}`)
       if (!app.maintenance && !context.flags.force) {
         cli.error('Application must be in maintenance mode or --force flag must be used')
         process.exit(1)
       }
 
       let maintenance = yield api.request(context, `/client/v11/databases/${addon.name}/maintenance`, 'POST')
-      console.log(maintenance.message)
-      process.exit(0)
+      cli.log(maintenance.message)
+      cli.exit(0)
     }
 
     let maintenance = yield api.request(context, `/client/v11/databases/${addon.name}/maintenance`, 'GET', null)
     cli.log(maintenance.message)
-  })
+  }))
 }

--- a/lib/commands/redis/maxmemory.js
+++ b/lib/commands/redis/maxmemory.js
@@ -1,4 +1,6 @@
 'use strict'
+
+let co = require('co')
 let cli = require('heroku-cli-util')
 let api = require('./shared.js')
 
@@ -19,13 +21,13 @@ module.exports = {
     volatile-random # evicts random keys but only those that have an expiry set
     volatile-ttl    # only evicts keys with an expiry set and a short TTL
   `,
-  run: cli.command(function * (context, heroku) {
+  run: cli.command(co.wrap(function * (context, heroku) {
     if (!context.flags.policy) {
       cli.error('Please specify a valid maxmemory eviction policy.')
       process.exit(1)
     }
     let addonsFilter = api.make_addons_filter(context.args.database)
-    let addons = addonsFilter(yield heroku.apps(context.app).addons().listByApp())
+    let addons = addonsFilter(yield heroku.get(`/apps/${context.app}/addons`))
     if (addons.length === 0) {
       cli.error('No redis databases found')
       process.exit(1)
@@ -38,5 +40,5 @@ module.exports = {
     let config = yield api.request(context, `/redis/v0/databases/${addon.name}/config`, 'PATCH', { maxmemory_policy: context.flags.policy })
     cli.log(`Maxmemory policy for ${addon.name} (${addon.config_vars.join(', ')}) set to ${config.maxmemory_policy.value}.`)
     cli.log(`${config.maxmemory_policy.value} ${config.maxmemory_policy.values[config.maxmemory_policy.value]}.`)
-  })
+  }))
 }

--- a/lib/commands/redis/maxmemory.js
+++ b/lib/commands/redis/maxmemory.js
@@ -36,7 +36,7 @@ module.exports = {
     }
     let addon = addons[0]
     let config = yield api.request(context, `/redis/v0/databases/${addon.name}/config`, 'PATCH', { maxmemory_policy: context.flags.policy })
-    console.log(`Maxmemory policy for ${addon.name} (${addon.config_vars.join(', ')}) set to ${config.maxmemory_policy.value}.`)
-    console.log(`${config.maxmemory_policy.value} ${config.maxmemory_policy.values[config.maxmemory_policy.value]}.`)
+    cli.log(`Maxmemory policy for ${addon.name} (${addon.config_vars.join(', ')}) set to ${config.maxmemory_policy.value}.`)
+    cli.log(`${config.maxmemory_policy.value} ${config.maxmemory_policy.values[config.maxmemory_policy.value]}.`)
   })
 }

--- a/lib/commands/redis/maxmemory.js
+++ b/lib/commands/redis/maxmemory.js
@@ -23,20 +23,11 @@ module.exports = {
   `,
   run: cli.command(co.wrap(function * (context, heroku) {
     if (!context.flags.policy) {
-      cli.error('Please specify a valid maxmemory eviction policy.')
-      process.exit(1)
+      cli.exit(1, 'Please specify a valid maxmemory eviction policy.')
     }
-    let addonsFilter = api.make_addons_filter(context.args.database)
-    let addons = addonsFilter(yield heroku.get(`/apps/${context.app}/addons`))
-    if (addons.length === 0) {
-      cli.error('No redis databases found')
-      process.exit(1)
-    } else if (addons.length > 1) {
-      let names = addons.map(function (addon) { return addon.name })
-      cli.error(`Please specify a single instance. Found: ${names.join(', ')}`)
-      process.exit(1)
-    }
-    let addon = addons[0]
+
+    let addon = yield api.getRedisAddon(context, heroku)
+
     let config = yield api.request(context, `/redis/v0/databases/${addon.name}/config`, 'PATCH', { maxmemory_policy: context.flags.policy })
     cli.log(`Maxmemory policy for ${addon.name} (${addon.config_vars.join(', ')}) set to ${config.maxmemory_policy.value}.`)
     cli.log(`${config.maxmemory_policy.value} ${config.maxmemory_policy.values[config.maxmemory_policy.value]}.`)

--- a/lib/commands/redis/promote.js
+++ b/lib/commands/redis/promote.js
@@ -12,19 +12,13 @@ module.exports = {
   args: [{name: 'database', optional: false}],
   description: 'sets DATABASE as your REDIS_URL',
   run: cli.command(co.wrap(function * (context, heroku) {
-    let addonsFilter = api.make_addons_filter(context.args.database)
-    let redisFilter = api.make_addons_filter('REDIS_URL')
     let addonsList = heroku.get(`/apps/${context.app}/addons`)
+
+    let addon = yield api.getRedisAddon(context, heroku, addonsList)
+
+    let redisFilter = api.make_addons_filter('REDIS_URL')
     let redis = redisFilter(yield addonsList)
-    let addons = addonsFilter(yield addonsList)
-    if (addons.length === 0) {
-      cli.error('No Redis instance found.')
-      process.exit(1)
-    } else if (addons.length > 1) {
-      let names = addons.map(function (addon) { return addon.name })
-      cli.error(`Please specify a single instance. Found: ${names.join(', ')}`)
-      process.exit(1)
-    }
+
     // Check if REDIS_URL is singlehandly assigned
     if (redis.length === 1 && redis[0].config_vars.length === 1) {
       let attachment = redis[0]
@@ -34,7 +28,7 @@ module.exports = {
         confirm: context.app
       }})
     }
-    let addon = addons[0]
+
     cli.log(`Promoting ${addon.name} to REDIS_URL on ${context.app}`)
     yield heroku.post('/addon-attachments', {body: {
       app: { name: context.app },

--- a/lib/commands/redis/promote.js
+++ b/lib/commands/redis/promote.js
@@ -33,7 +33,7 @@ module.exports = {
       })
     }
     let addon = addons[0]
-    console.log(`Promoting ${addon.name} to REDIS_URL on ${context.app}`)
+    cli.log(`Promoting ${addon.name} to REDIS_URL on ${context.app}`)
     yield heroku.post('/addon-attachments', {
       app: { name: context.app },
       addon: { name: addon.name },

--- a/lib/commands/redis/promote.js
+++ b/lib/commands/redis/promote.js
@@ -1,4 +1,6 @@
 'use strict'
+
+let co = require('co')
 let cli = require('heroku-cli-util')
 let api = require('./shared.js')
 
@@ -9,10 +11,10 @@ module.exports = {
   needsAuth: true,
   args: [{name: 'database', optional: false}],
   description: 'sets DATABASE as your REDIS_URL',
-  run: cli.command(function * (context, heroku) {
+  run: cli.command(co.wrap(function * (context, heroku) {
     let addonsFilter = api.make_addons_filter(context.args.database)
     let redisFilter = api.make_addons_filter('REDIS_URL')
-    let addonsList = heroku.apps(context.app).addons().listByApp()
+    let addonsList = heroku.get(`/apps/${context.app}/addons`)
     let redis = redisFilter(yield addonsList)
     let addons = addonsFilter(yield addonsList)
     if (addons.length === 0) {
@@ -26,19 +28,19 @@ module.exports = {
     // Check if REDIS_URL is singlehandly assigned
     if (redis.length === 1 && redis[0].config_vars.length === 1) {
       let attachment = redis[0]
-      yield heroku.post('/addon-attachments', {
+      yield heroku.post('/addon-attachments', {body: {
         app: { name: context.app },
         addon: { name: attachment.name },
         confirm: context.app
-      })
+      }})
     }
     let addon = addons[0]
     cli.log(`Promoting ${addon.name} to REDIS_URL on ${context.app}`)
-    yield heroku.post('/addon-attachments', {
+    yield heroku.post('/addon-attachments', {body: {
       app: { name: context.app },
       addon: { name: addon.name },
       confirm: context.app,
       name: 'REDIS'
-    })
-  })
+    }})
+  }))
 }

--- a/lib/commands/redis/shared.js
+++ b/lib/commands/redis/shared.js
@@ -54,7 +54,24 @@ function make_addons_filter (filter) {
   return on_response
 }
 
+function * getRedisAddon (context, heroku, addonsList) {
+  addonsList = addonsList || heroku.get(`/apps/${context.app}/addons`)
+
+  let addonsFilter = make_addons_filter(context.args.database)
+  let addons = addonsFilter(yield addonsList)
+
+  if (addons.length === 0) {
+    cli.exit(1, 'No Redis instances found.')
+  } else if (addons.length > 1) {
+    let names = addons.map(function (addon) { return addon.name })
+    cli.exit(1, `Please specify a single instance. Found: ${names.join(', ')}`)
+  }
+
+  return addons[0]
+}
+
 module.exports = {
   request: request,
-  make_addons_filter: make_addons_filter
+  make_addons_filter: make_addons_filter,
+  getRedisAddon: getRedisAddon
 }

--- a/lib/commands/redis/timeout.js
+++ b/lib/commands/redis/timeout.js
@@ -14,20 +14,11 @@ module.exports = {
   help: 'Sets the number of seconds to wait before killing idle connections. A value of zero means that connections will not be closed.',
   run: cli.command(co.wrap(function * (context, heroku) {
     if (!context.flags.seconds) {
-      cli.error('Please specify a valid timeout value.')
-      process.exit(1)
+      cli.exit(1, 'Please specify a valid timeout value.')
     }
-    let addonsFilter = api.make_addons_filter(context.args.database)
-    let addons = addonsFilter(yield heroku.get(`/apps/${context.app}/addons`))
-    if (addons.length === 0) {
-      cli.error('No Redis instances found.')
-      process.exit(1)
-    } else if (addons.length > 1) {
-      let names = addons.map(function (addon) { return addon.name })
-      cli.error(`Please specify a single instance. Found: ${names.join(', ')}`)
-      process.exit(1)
-    }
-    let addon = addons[0]
+
+    let addon = yield api.getRedisAddon(context, heroku)
+
     let config = yield api.request(context, `/redis/v0/databases/${addon.name}/config`, 'PATCH', { timeout: parseInt(context.flags.seconds, 10) })
     cli.log(`Timeout for ${addon.name} (${addon.config_vars.join(', ')}) set to ${config.timeout.value} seconds.`)
     if (config.timeout.value === 0) {

--- a/lib/commands/redis/timeout.js
+++ b/lib/commands/redis/timeout.js
@@ -1,4 +1,5 @@
 'use strict'
+let co = require('co')
 let cli = require('heroku-cli-util')
 let api = require('./shared.js')
 
@@ -11,13 +12,13 @@ module.exports = {
   flags: [{name: 'seconds', char: 's', description: 'set timeout value', hasValue: true}],
   description: 'set the number of seconds to wait before killing idle connections',
   help: 'Sets the number of seconds to wait before killing idle connections. A value of zero means that connections will not be closed.',
-  run: cli.command(function * (context, heroku) {
+  run: cli.command(co.wrap(function * (context, heroku) {
     if (!context.flags.seconds) {
       cli.error('Please specify a valid timeout value.')
       process.exit(1)
     }
     let addonsFilter = api.make_addons_filter(context.args.database)
-    let addons = addonsFilter(yield heroku.apps(context.app).addons().listByApp())
+    let addons = addonsFilter(yield heroku.get(`/apps/${context.app}/addons`))
     if (addons.length === 0) {
       cli.error('No Redis instances found.')
       process.exit(1)
@@ -34,5 +35,5 @@ module.exports = {
     } else {
       cli.log(`Connections to the Redis instance will be stopped after idling for ${config.timeout.value} seconds.`)
     }
-  })
+  }))
 }

--- a/lib/commands/redis/timeout.js
+++ b/lib/commands/redis/timeout.js
@@ -28,11 +28,11 @@ module.exports = {
     }
     let addon = addons[0]
     let config = yield api.request(context, `/redis/v0/databases/${addon.name}/config`, 'PATCH', { timeout: parseInt(context.flags.seconds, 10) })
-    console.log(`Timeout for ${addon.name} (${addon.config_vars.join(', ')}) set to ${config.timeout.value} seconds.`)
+    cli.log(`Timeout for ${addon.name} (${addon.config_vars.join(', ')}) set to ${config.timeout.value} seconds.`)
     if (config.timeout.value === 0) {
-      console.log('Connections to the Redis instance can idle indefinitely.')
+      cli.log('Connections to the Redis instance can idle indefinitely.')
     } else {
-      console.log(`Connections to the Redis instance will be stopped after idling for ${config.timeout.value} seconds.`)
+      cli.log(`Connections to the Redis instance will be stopped after idling for ${config.timeout.value} seconds.`)
     }
   })
 }

--- a/lib/commands/redis/wait.js
+++ b/lib/commands/redis/wait.js
@@ -1,4 +1,6 @@
 'use strict'
+
+let co = require('co')
 let api = require('./shared.js')
 let cli = require('heroku-cli-util')
 
@@ -9,9 +11,9 @@ module.exports = {
   needsAuth: true,
   args: [{name: 'database', optional: true}],
   description: 'wait for Redis instance to be available',
-  run: cli.command(function * (context, heroku) {
+  run: cli.command(co.wrap(function * (context, heroku) {
     let addonsFilter = api.make_addons_filter(context.args.database)
-    let addons = addonsFilter(yield heroku.apps(context.app).addons().listByApp())
+    let addons = addonsFilter(yield heroku.get(`/apps/${context.app}/addons`))
     if (addons.length === 0) {
       cli.error('No Redis instances found.')
       process.exit(1)
@@ -31,5 +33,5 @@ module.exports = {
         clearInterval(interval)
       })
     }, 500)
-  })
+  }))
 }

--- a/lib/commands/redis/wait.js
+++ b/lib/commands/redis/wait.js
@@ -12,17 +12,8 @@ module.exports = {
   args: [{name: 'database', optional: true}],
   description: 'wait for Redis instance to be available',
   run: cli.command(co.wrap(function * (context, heroku) {
-    let addonsFilter = api.make_addons_filter(context.args.database)
-    let addons = addonsFilter(yield heroku.get(`/apps/${context.app}/addons`))
-    if (addons.length === 0) {
-      cli.error('No Redis instances found.')
-      process.exit(1)
-    } else if (addons.length > 1) {
-      let names = addons.map(function (addon) { return addon.name })
-      cli.error(`Please specify a single instance. Found: ${names.join(', ')}`)
-      process.exit(1)
-    }
-    let addon = addons[0]
+    let addon = yield api.getRedisAddon(context, heroku)
+
     let interval = setInterval(function () {
       api.request(context, `/redis/v0/databases/${addon.name}/wait`, 'GET').then(function (status) {
         if (!status['waiting?']) {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "license": "ISC",
   "scripts": {
-    "test": "standard"
+    "test": "nyc mocha && standard | snazzy"
   },
   "dependencies": {
     "heroku-cli-util": "5.10.10",
@@ -25,6 +25,15 @@
     "ssh2": "0.4.11"
   },
   "devDependencies": {
+    "chai": "3.5.0",
+    "chai-as-promised": "5.3.0",
+    "lolex": "1.5.0",
+    "mocha": "2.4.5",
+    "nock": "3.2.0",
+    "nyc": "6.4.4",
+    "proxyquire": "1.7.9",
+    "sinon": "1.17.2",
+    "snazzy": "4.0.0",
     "standard": "6.0.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "test": "nyc mocha && standard | snazzy"
   },
   "dependencies": {
-    "heroku-cli-util": "5.10.10",
+    "co": "4.6.0",
+    "heroku-cli-util": "6.0.11",
     "heroku-client": "2.4.0",
     "ioredis": "1.9.0",
     "ssh2": "0.4.11"

--- a/test/commands/redis/cli.js
+++ b/test/commands/redis/cli.js
@@ -1,0 +1,111 @@
+'use strict'
+/* globals describe it beforeEach cli */
+
+let nock = require('nock')
+let sinon = require('sinon')
+let proxyquire = require('proxyquire').noCallThru()
+let expect = require('chai').expect
+
+let command, net, tls, tunnel
+
+describe('heroku redis:cli', function () {
+  beforeEach(function () {
+    cli.mockConsole()
+
+    let client = {
+      write: sinon.stub(),
+      on: sinon.stub()
+    }
+
+    net = {
+      connect: sinon.stub().returns(client)
+    }
+
+    tls = {
+      connect: sinon.stub().returns(client)
+    }
+
+    tunnel = sinon.stub()
+
+    let Client = function () {
+      this.on = sinon.stub()
+      this.connect = tunnel
+    }
+
+    let ssh2 = { Client }
+
+    command = proxyquire('../../../lib/commands/redis/cli.js', {net, tls, ssh2})
+  })
+
+  it('# for hobby it uses net.connect', function () {
+    let app = nock('https://api.heroku.com:443')
+      .get('/apps/example/addons').reply(200, [
+        {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_FOO', 'REDIS_BAR']}
+      ])
+
+    let configVars = nock('https://api.heroku.com:443')
+      .get('/apps/example/config-vars').reply(200, {'FOO': 'BAR'})
+
+    let redis = nock('https://redis-api.heroku.com:443')
+      .get('/redis/v0/databases/redis-haiku').reply(200, {
+        resource_url: 'redis://foobar:password@example.com:8649',
+        plan: 'hobby'
+      })
+
+    return command.run({app: 'example', flags: {confirm: 'example'}, args: {}, auth: {username: 'foobar', password: 'password'}})
+    .then(() => app.done())
+    .then(() => configVars.done())
+    .then(() => redis.done())
+    .then(() => expect(cli.stdout).to.equal('Connecting to redis-haiku (REDIS_FOO, REDIS_BAR):\n'))
+    .then(() => expect(cli.stderr).to.equal(''))
+    .then(() => expect(net.connect.called).to.equal(true))
+  })
+
+  it('# for premium it uses tls.connect', function () {
+    let app = nock('https://api.heroku.com:443')
+      .get('/apps/example/addons').reply(200, [
+        {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_FOO', 'REDIS_BAR']}
+      ])
+
+    let configVars = nock('https://api.heroku.com:443')
+      .get('/apps/example/config-vars').reply(200, {'FOO': 'BAR'})
+
+    let redis = nock('https://redis-api.heroku.com:443')
+      .get('/redis/v0/databases/redis-haiku').reply(200, {
+        resource_url: 'redis://foobar:password@example.com:8649',
+        plan: 'premium-0'
+      })
+
+    return command.run({app: 'example', flags: {confirm: 'example'}, args: {}, auth: {username: 'foobar', password: 'password'}})
+    .then(() => app.done())
+    .then(() => configVars.done())
+    .then(() => redis.done())
+    .then(() => expect(cli.stdout).to.equal('Connecting to redis-haiku (REDIS_FOO, REDIS_BAR):\n'))
+    .then(() => expect(cli.stderr).to.equal(''))
+    .then(() => expect(tls.connect.called).to.equal(true))
+  })
+
+  it('# for bastion it uses tunnel.connect', function () {
+    let app = nock('https://api.heroku.com:443')
+      .get('/apps/example/addons').reply(200, [
+        {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_BASTIONS']}
+      ])
+
+    let configVars = nock('https://api.heroku.com:443')
+      .get('/apps/example/config-vars').reply(200, {'REDIS_BASTIONS': 'example.com'})
+
+    let redis = nock('https://redis-api.heroku.com:443')
+      .get('/redis/v0/databases/redis-haiku').reply(200, {
+        resource_url: 'redis://foobar:password@example.com:8649',
+        plan: 'premium-0'
+      })
+
+    return command.run({app: 'example', flags: {confirm: 'example'}, args: {}, auth: {username: 'foobar', password: 'password'}})
+    .then(() => app.done())
+    .then(() => configVars.done())
+    .then(() => redis.done())
+    .then(() => expect(cli.stdout).to.equal('Connecting to redis-haiku (REDIS_BASTIONS):\n'))
+    .then(() => expect(cli.stderr).to.equal(''))
+    .then(() => expect(tunnel.called).to.equal(true))
+  })
+})

--- a/test/commands/redis/cli.js
+++ b/test/commands/redis/cli.js
@@ -9,6 +9,11 @@ let expect = require('chai').expect
 let command, net, tls, tunnel
 
 describe('heroku redis:cli', function () {
+  let command = proxyquire('../../../lib/commands/redis/cli.js', {net: {}, tls: {}, ssh2: {}})
+  require('./shared.js').shouldHandleArgs(command)
+})
+
+describe('heroku redis:cli', function () {
   beforeEach(function () {
     cli.mockConsole()
 

--- a/test/commands/redis/credentials.js
+++ b/test/commands/redis/credentials.js
@@ -1,0 +1,49 @@
+'use strict'
+/* globals describe it beforeEach cli */
+
+let nock = require('nock')
+let expect = require('chai').expect
+
+let command = require('../../../lib/commands/redis/credentials.js')
+
+describe('heroku redis:credentials', function () {
+  beforeEach(function () {
+    cli.mockConsole()
+    nock.cleanAll()
+  })
+
+  it('# displays the redis credentials', function () {
+    let app = nock('https://api.heroku.com:443')
+      .get('/apps/example/addons').reply(200, [
+        {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_FOO', 'REDIS_BAR']}
+      ])
+
+    let redis = nock('https://redis-api.heroku.com:443')
+      .get('/redis/v0/databases/redis-haiku').reply(200, {
+        info: [{name: 'Foo', values: ['Bar', 'Biz']}],
+        resource_url: 'redis://foobar:password@hostname:8649'
+      })
+
+    return command.run({app: 'example', flags: {}, args: {}, auth: {username: 'foobar', password: 'password'}})
+    .then(() => app.done())
+    .then(() => redis.done())
+    .then(() => expect(cli.stdout).to.equal('redis://foobar:password@hostname:8649\n'))
+    .then(() => expect(cli.stderr).to.equal(''))
+  })
+
+  it('# resets the redis credentials', function () {
+    let app = nock('https://api.heroku.com:443')
+      .get('/apps/example/addons').reply(200, [
+        {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_FOO', 'REDIS_BAR']}
+      ])
+
+    let redis = nock('https://redis-api.heroku.com:443')
+      .post('/redis/v0/databases/redis-haiku/credentials_rotation').reply(200, {})
+
+    return command.run({app: 'example', flags: {reset: true}, args: {}, auth: {username: 'foobar', password: 'password'}})
+    .then(() => app.done())
+    .then(() => redis.done())
+    .then(() => expect(cli.stdout).to.equal('Resetting credentials for redis-haiku\n'))
+    .then(() => expect(cli.stderr).to.equal(''))
+  })
+})

--- a/test/commands/redis/credentials.js
+++ b/test/commands/redis/credentials.js
@@ -7,6 +7,10 @@ let expect = require('chai').expect
 let command = require('../../../lib/commands/redis/credentials.js')
 
 describe('heroku redis:credentials', function () {
+  require('./shared.js').shouldHandleArgs(command)
+})
+
+describe('heroku redis:credentials', function () {
   beforeEach(function () {
     cli.mockConsole()
     nock.cleanAll()

--- a/test/commands/redis/info.js
+++ b/test/commands/redis/info.js
@@ -1,0 +1,73 @@
+'use strict'
+/* globals describe it beforeEach cli */
+
+let expect = require('chai').expect
+let nock = require('nock')
+let command = require('../../../lib/commands/redis/info.js')
+
+describe('heroku redis:info', function () {
+  beforeEach(function () {
+    cli.mockConsole()
+    nock.cleanAll()
+  })
+
+  it('# prints out nothing when there is no redis DB', function () {
+    let app = nock('https://api.heroku.com:443')
+      .get('/apps/example/addons').reply(200, [])
+
+    return command.run({app: 'example', args: {}})
+    .then(() => app.done())
+    .then(() => expect(cli.stdout).to.equal(''))
+    .then(() => expect(cli.stderr).to.equal(''))
+  })
+
+  it('# prints out redis info', function () {
+    let app = nock('https://api.heroku.com:443')
+      .get('/apps/example/addons').reply(200, [
+        {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_FOO', 'REDIS_BAR']}
+      ])
+
+    let redis = nock('https://redis-api.heroku.com:443')
+      .get('/redis/v0/databases/redis-haiku').reply(200, {info: [
+        {name: 'Foo', values: ['Bar', 'Biz']}
+      ]})
+
+    return command.run({app: 'example', args: {}, auth: {username: 'foobar', password: 'password'}})
+    .then(() => app.done())
+    .then(() => redis.done())
+    .then(() => expect(cli.stdout).to.equal(
+`=== redis-haiku (REDIS_FOO, REDIS_BAR)
+Foo: Bar
+     Biz
+`))
+    .then(() => expect(cli.stderr).to.equal(''))
+  })
+
+  it('# prints out redis info when not found', function () {
+    let app = nock('https://api.heroku.com:443')
+      .get('/apps/example/addons').reply(200, [
+        {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_FOO', 'REDIS_BAR']}
+      ])
+
+    let redis = nock('https://redis-api.heroku.com:443')
+      .get('/redis/v0/databases/redis-haiku').reply(404, {})
+
+    return command.run({app: 'example', args: {}, auth: {username: 'foobar', password: 'password'}})
+    .then(() => app.done())
+    .then(() => redis.done())
+    .then(() => expect(cli.stdout).to.equal(''))
+    .then(() => expect(cli.stderr).to.equal(''))
+  })
+
+  it('# prints out redis info when error', function () {
+    nock('https://api.heroku.com:443')
+      .get('/apps/example/addons').reply(200, [
+        {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_FOO', 'REDIS_BAR']}
+      ])
+
+    nock('https://redis-api.heroku.com:443')
+      .get('/redis/v0/databases/redis-haiku').reply(503, {})
+
+    return expect(command.run({app: 'example', args: {}, auth: {username: 'foobar', password: 'password'}})).to.be.rejectedWith(/Expected response to be successful, got 503/)
+  })
+})

--- a/test/commands/redis/maintenance.js
+++ b/test/commands/redis/maintenance.js
@@ -3,6 +3,7 @@
 
 let expect = require('chai').expect
 let nock = require('nock')
+let exit = require('heroku-cli-util').exit
 
 let command = require('../../../lib/commands/redis/maintenance.js')
 
@@ -10,6 +11,7 @@ describe('heroku redis:maintenance', function () {
   beforeEach(function () {
     cli.mockConsole()
     nock.cleanAll()
+    exit.mock()
   })
 
   it('# shows the maintenance message', function () {
@@ -23,6 +25,44 @@ describe('heroku redis:maintenance', function () {
 
     return command.run({app: 'example', args: {}, flags: {}, auth: {username: 'foobar', password: 'password'}})
     .then(() => app.done())
+    .then(() => redis.done())
+    .then(() => expect(cli.stdout).to.equal('Message\n'))
+    .then(() => expect(cli.stderr).to.equal(''))
+  })
+
+  it('# sets the maintenance window', function () {
+    let app = nock('https://api.heroku.com:443')
+      .get('/apps/example/addons').reply(200, [
+        {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, plan: {name: 'premium-0'}, config_vars: ['REDIS_FOO', 'REDIS_BAR']}
+      ])
+
+    let redis = nock('https://redis-api.heroku.com:443')
+      .put('/client/v11/databases/redis-haiku/maintenance_window', {
+        description: 'Mon 10:00'
+      }).reply(200, {window: 'Mon 10:00'})
+
+    return expect(command.run({app: 'example', args: {}, flags: {window: 'Mon 10:00'}, auth: {username: 'foobar', password: 'password'}})).to.be.rejectedWith(exit.ErrorExit)
+    .then(() => app.done())
+    .then(() => redis.done)
+    .then(() => expect(cli.stdout).to.equal('Maintenance window for redis-haiku (REDIS_FOO, REDIS_BAR) set to Mon 10:00.\n'))
+    .then(() => expect(cli.stderr).to.equal(''))
+  })
+
+  it('# runs the maintenance', function () {
+    let app = nock('https://api.heroku.com:443')
+      .get('/apps/example/addons').reply(200, [
+        {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, plan: {name: 'premium-0'}, config_vars: ['REDIS_FOO', 'REDIS_BAR']}
+      ])
+
+    let app_info = nock('https://api.heroku.com:443')
+      .get('/apps/example').reply(200, { maintenance: true })
+
+    let redis = nock('https://redis-api.heroku.com:443')
+      .post('/client/v11/databases/redis-haiku/maintenance').reply(200, {message: 'Message'})
+
+    return expect(command.run({app: 'example', args: {}, flags: {run: true}, auth: {username: 'foobar', password: 'password'}})).to.be.rejectedWith(exit.ErrorExit)
+    .then(() => app.done())
+    .then(() => app_info.done())
     .then(() => redis.done())
     .then(() => expect(cli.stdout).to.equal('Message\n'))
     .then(() => expect(cli.stderr).to.equal(''))

--- a/test/commands/redis/maintenance.js
+++ b/test/commands/redis/maintenance.js
@@ -1,0 +1,30 @@
+'use strict'
+/* globals describe it beforeEach cli */
+
+let expect = require('chai').expect
+let nock = require('nock')
+
+let command = require('../../../lib/commands/redis/maintenance.js')
+
+describe('heroku redis:maintenance', function () {
+  beforeEach(function () {
+    cli.mockConsole()
+    nock.cleanAll()
+  })
+
+  it('# shows the maintenance message', function () {
+    let app = nock('https://api.heroku.com:443')
+      .get('/apps/example/addons').reply(200, [
+        {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, plan: {name: 'premium-0'}, config_vars: ['REDIS_FOO', 'REDIS_BAR']}
+      ])
+
+    let redis = nock('https://redis-api.heroku.com:443')
+      .get('/client/v11/databases/redis-haiku/maintenance').reply(200, {message: 'Message'})
+
+    return command.run({app: 'example', args: {}, flags: {}, auth: {username: 'foobar', password: 'password'}})
+    .then(() => app.done())
+    .then(() => redis.done())
+    .then(() => expect(cli.stdout).to.equal('Message\n'))
+    .then(() => expect(cli.stderr).to.equal(''))
+  })
+})

--- a/test/commands/redis/maxmemory.js
+++ b/test/commands/redis/maxmemory.js
@@ -1,0 +1,36 @@
+'use strict'
+/* globals describe it beforeEach cli */
+
+let expect = require('chai').expect
+let nock = require('nock')
+
+let command = require('../../../lib/commands/redis/maxmemory.js')
+
+describe('heroku redis:maxmemory', function () {
+  beforeEach(function () {
+    cli.mockConsole()
+    nock.cleanAll()
+  })
+
+  it('# sets the key eviction policy', function () {
+    let app = nock('https://api.heroku.com:443')
+      .get('/apps/example/addons').reply(200, [
+        {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_FOO', 'REDIS_BAR']}
+      ])
+
+    let redis = nock('https://redis-api.heroku.com:443')
+      .patch('/redis/v0/databases/redis-haiku/config', {maxmemory_policy: 'noeviction'}).reply(200, {
+        maxmemory_policy: {value: 'noeviction', values: {'noeviction': 'return errors when memory limit is reached'}}
+      })
+
+    return command.run({app: 'example', flags: {policy: 'noeviction'}, args: {}, auth: {username: 'foobar', password: 'password'}})
+    .then(() => app.done())
+    .then(() => redis.done())
+    .then(() => expect(cli.stdout).to.equal(
+`Maxmemory policy for redis-haiku (REDIS_FOO, REDIS_BAR) set to noeviction.
+noeviction return errors when memory limit is reached.
+`
+))
+    .then(() => expect(cli.stderr).to.equal(''))
+  })
+})

--- a/test/commands/redis/maxmemory.js
+++ b/test/commands/redis/maxmemory.js
@@ -3,13 +3,19 @@
 
 let expect = require('chai').expect
 let nock = require('nock')
+let exit = require('heroku-cli-util').exit
 
 let command = require('../../../lib/commands/redis/maxmemory.js')
+
+describe('heroku redis:maxmemory', function () {
+  require('./shared.js').shouldHandleArgs(command, {policy: 'noeviction'})
+})
 
 describe('heroku redis:maxmemory', function () {
   beforeEach(function () {
     cli.mockConsole()
     nock.cleanAll()
+    exit.mock()
   })
 
   it('# sets the key eviction policy', function () {
@@ -32,5 +38,11 @@ noeviction return errors when memory limit is reached.
 `
 ))
     .then(() => expect(cli.stderr).to.equal(''))
+  })
+
+  it('# errors on missing eviction policy', function () {
+    return expect(command.run({app: 'example', flags: {}, args: {}})).to.be.rejectedWith(exit.ErrorExit)
+    .then(() => expect(cli.stdout).to.equal(''))
+    .then(() => expect(cli.stderr).to.equal(' ▸    Please specify a valid maxmemory eviction policy.\n'))
   })
 })

--- a/test/commands/redis/promote.js
+++ b/test/commands/redis/promote.js
@@ -7,6 +7,10 @@ let expect = require('chai').expect
 let command = require('../../../lib/commands/redis/promote.js')
 
 describe('heroku redis:promote', function () {
+  require('./shared.js').shouldHandleArgs(command)
+})
+
+describe('heroku redis:promote', function () {
   beforeEach(function () {
     cli.mockConsole()
     nock.cleanAll()

--- a/test/commands/redis/promote.js
+++ b/test/commands/redis/promote.js
@@ -1,0 +1,66 @@
+'use strict'
+/* globals describe it beforeEach cli */
+
+let nock = require('nock')
+let expect = require('chai').expect
+
+let command = require('../../../lib/commands/redis/promote.js')
+
+describe('heroku redis:promote', function () {
+  beforeEach(function () {
+    cli.mockConsole()
+    nock.cleanAll()
+  })
+
+  it('# promotes', function () {
+    let app = nock('https://api.heroku.com:443')
+      .get('/apps/example/addons').reply(200, [
+        {name: 'redis-silver-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_URL', 'HEROKU_REDIS_SILVER_URL']},
+        {name: 'redis-gold-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['HEROKU_REDIS_GOLD_URL']}
+      ])
+
+    let attach = nock('https://api.heroku.com:443')
+      .post('/addon-attachments', {
+        'app': {'name': 'example'},
+        'addon': {'name': 'redis-gold-haiku'},
+        'confirm': 'example',
+        'name': 'REDIS'
+      }).reply(200, {})
+
+    return command.run({app: 'example', flags: {}, args: {database: 'redis-gold-haiku'}, auth: {username: 'foobar', password: 'password'}})
+    .then(() => app.done())
+    .then(() => attach.done())
+    .then(() => expect(cli.stdout).to.equal('Promoting redis-gold-haiku to REDIS_URL on example\n'))
+    .then(() => expect(cli.stderr).to.equal(''))
+  })
+
+  it('# promotes and attaches existing REDIS_URL', function () {
+    let app = nock('https://api.heroku.com:443')
+      .get('/apps/example/addons').reply(200, [
+        {name: 'redis-silver-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_URL']},
+        {name: 'redis-gold-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['HEROKU_REDIS_GOLD_URL']}
+      ])
+
+    let attach_redis_url = nock('https://api.heroku.com:443')
+      .post('/addon-attachments', {
+        'app': {'name': 'example'},
+        'addon': {'name': 'redis-silver-haiku'},
+        'confirm': 'example'
+      }).reply(200, {})
+
+    let attach = nock('https://api.heroku.com:443')
+      .post('/addon-attachments', {
+        'app': {'name': 'example'},
+        'addon': {'name': 'redis-gold-haiku'},
+        'confirm': 'example',
+        'name': 'REDIS'
+      }).reply(200, {})
+
+    return command.run({app: 'example', flags: {}, args: {database: 'redis-gold-haiku'}, auth: {username: 'foobar', password: 'password'}})
+    .then(() => app.done())
+    .then(() => attach_redis_url.done())
+    .then(() => attach.done())
+    .then(() => expect(cli.stdout).to.equal('Promoting redis-gold-haiku to REDIS_URL on example\n'))
+    .then(() => expect(cli.stderr).to.equal(''))
+  })
+})

--- a/test/commands/redis/shared.js
+++ b/test/commands/redis/shared.js
@@ -1,0 +1,39 @@
+'use strict'
+/* globals describe it beforeEach cli */
+
+let expect = require('chai').expect
+let nock = require('nock')
+let exit = require('heroku-cli-util').exit
+
+exports.shouldHandleArgs = function (command, flags) {
+  flags = flags || {}
+
+  describe('', function () {
+    beforeEach(function () {
+      cli.mockConsole()
+      exit.mock()
+      nock.cleanAll()
+    })
+
+    it('# shows an error if an app has no addons', function () {
+      let app = nock('https://api.heroku.com:443')
+      .get('/apps/example/addons').reply(200, [])
+      return expect(command.run({app: 'example', flags: flags, args: {}})).to.be.rejectedWith(exit.ErrorExit)
+      .then(() => app.done())
+      .then(() => expect(cli.stdout).to.equal(''))
+      .then(() => expect(cli.stderr).to.equal(' ▸    No Redis instances found.\n'))
+    })
+
+    it('# shows an error if the addon is ambiguous', function () {
+      let app = nock('https://api.heroku.com:443')
+      .get('/apps/example/addons').reply(200, [
+        {name: 'redis-haiku-a', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_FOO']},
+        {name: 'redis-haiku-b', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_BAR']}
+      ])
+      return expect(command.run({app: 'example', flags: flags, args: {}})).to.be.rejectedWith(exit.ErrorExit)
+      .then(() => app.done())
+      .then(() => expect(cli.stdout).to.equal(''))
+      .then(() => expect(cli.stderr).to.equal(' ▸    Please specify a single instance. Found: redis-haiku-a, redis-haiku-b\n'))
+    })
+  })
+}

--- a/test/commands/redis/timeout.js
+++ b/test/commands/redis/timeout.js
@@ -3,13 +3,19 @@
 
 let expect = require('chai').expect
 let nock = require('nock')
+let exit = require('heroku-cli-util').exit
 
 let command = require('../../../lib/commands/redis/timeout.js')
+
+describe('heroku redis:timeout', function () {
+  require('./shared.js').shouldHandleArgs(command, {seconds: '5'})
+})
 
 describe('heroku redis:timeout', function () {
   beforeEach(function () {
     cli.mockConsole()
     nock.cleanAll()
+    exit.mock()
   })
 
   it('# sets the timout', function () {
@@ -52,5 +58,11 @@ Connections to the Redis instance will be stopped after idling for 5 seconds.
 Connections to the Redis instance can idle indefinitely.
 `))
     .then(() => expect(cli.stderr).to.equal(''))
+  })
+
+  it('# errors on missing timeout', function () {
+    return expect(command.run({app: 'example', flags: {}, args: {}})).to.be.rejectedWith(exit.ErrorExit)
+    .then(() => expect(cli.stdout).to.equal(''))
+    .then(() => expect(cli.stderr).to.equal(' ▸    Please specify a valid timeout value.\n'))
   })
 })

--- a/test/commands/redis/timeout.js
+++ b/test/commands/redis/timeout.js
@@ -1,0 +1,56 @@
+'use strict'
+/* globals describe it beforeEach cli */
+
+let expect = require('chai').expect
+let nock = require('nock')
+
+let command = require('../../../lib/commands/redis/timeout.js')
+
+describe('heroku redis:timeout', function () {
+  beforeEach(function () {
+    cli.mockConsole()
+    nock.cleanAll()
+  })
+
+  it('# sets the timout', function () {
+    let app = nock('https://api.heroku.com:443')
+      .get('/apps/example/addons').reply(200, [
+        {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_FOO', 'REDIS_BAR']}
+      ])
+
+    let redis = nock('https://redis-api.heroku.com:443')
+      .patch('/redis/v0/databases/redis-haiku/config', {timeout: 5}).reply(200, {
+        timeout: {value: 5}
+      })
+
+    return command.run({app: 'example', flags: {seconds: '5'}, args: {}, auth: {username: 'foobar', password: 'password'}})
+    .then(() => app.done())
+    .then(() => redis.done())
+    .then(() => expect(cli.stdout).to.equal(
+ `Timeout for redis-haiku (REDIS_FOO, REDIS_BAR) set to 5 seconds.
+Connections to the Redis instance will be stopped after idling for 5 seconds.
+`))
+    .then(() => expect(cli.stderr).to.equal(''))
+  })
+
+  it('# sets the timout to zero', function () {
+    let app = nock('https://api.heroku.com:443')
+      .get('/apps/example/addons').reply(200, [
+        {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_FOO', 'REDIS_BAR']}
+      ])
+
+    let redis = nock('https://redis-api.heroku.com:443')
+      .patch('/redis/v0/databases/redis-haiku/config', {timeout: 0}).reply(200, {
+        timeout: {value: 0}
+      })
+
+    return command.run({app: 'example', flags: {seconds: '0'}, args: {}, auth: {username: 'foobar', password: 'password'}})
+    .then(() => app.done())
+    .then(() => redis.done())
+    .then(() => expect(cli.stdout).to.equal(
+ `Timeout for redis-haiku (REDIS_FOO, REDIS_BAR) set to 0 seconds.
+Connections to the Redis instance can idle indefinitely.
+`))
+    .then(() => expect(cli.stderr).to.equal(''))
+  })
+})

--- a/test/commands/redis/wait.js
+++ b/test/commands/redis/wait.js
@@ -1,0 +1,64 @@
+'use strict'
+/* globals describe it beforeEach afterEach cli */
+
+let nock = require('nock')
+let lolex = require('lolex')
+
+let command = require('../../../lib/commands/redis/wait.js')
+
+let clock
+
+describe('heroku redis:cli', function () {
+  beforeEach(function () {
+    cli.mockConsole()
+    nock.cleanAll()
+    clock = lolex.install()
+    clock.setTimeout = function (fn, timeout) { fn() }
+  })
+
+  afterEach(function () {
+    clock.uninstall()
+  })
+
+  it('# waits until waiting? false', function () {
+    let app = nock('https://api.heroku.com:443')
+      .get('/apps/example/addons').reply(200, [
+        {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_FOO', 'REDIS_BAR']}
+      ])
+
+    let redis_waiting = nock('https://redis-api.heroku.com:443')
+      .get('/redis/v0/databases/redis-haiku/wait').reply(200, {'waiting?': false})
+
+    let redis_done = nock('https://redis-api.heroku.com:443')
+      .get('/redis/v0/databases/redis-haiku/wait').reply(200, {'waiting?': true})
+
+    return command.run({app: 'example', flags: {}, args: {}, auth: {username: 'foobar', password: 'password'}})
+    .then(() => app.done())
+    .then(() => clock.next())
+    .then(() => redis_waiting.done())
+    .then(() => clock.next())
+    .then(() => redis_done.done())
+    // todo: lolex has a bug in clearInterval should verify no more work when fixed
+  })
+
+  it('# waits until error', function () {
+    let app = nock('https://api.heroku.com:443')
+      .get('/apps/example/addons').reply(200, [
+        {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_FOO', 'REDIS_BAR']}
+      ])
+
+    let redis_waiting = nock('https://redis-api.heroku.com:443')
+      .get('/redis/v0/databases/redis-haiku/wait').reply(200, {'waiting?': false})
+
+    let redis_done = nock('https://redis-api.heroku.com:443')
+      .get('/redis/v0/databases/redis-haiku/wait').reply(503, {'error': 'Error'})
+
+    return command.run({app: 'example', flags: {}, args: {}, auth: {username: 'foobar', password: 'password'}})
+    .then(() => app.done())
+    .then(() => clock.next())
+    .then(() => redis_waiting.done())
+    .then(() => clock.next())
+    .then(() => redis_done.done())
+    // todo: lolex has a bug in clearInterval should verify no more work when fixed
+  })
+})

--- a/test/commands/redis/wait.js
+++ b/test/commands/redis/wait.js
@@ -8,6 +8,10 @@ let command = require('../../../lib/commands/redis/wait.js')
 
 let clock
 
+describe('heroku redis:timeout', function () {
+  require('./shared.js').shouldHandleArgs(command)
+})
+
 describe('heroku redis:cli', function () {
   beforeEach(function () {
     cli.mockConsole()

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,14 @@
+'use strict'
+/* globals cli */
+
+global.cli = require('heroku-cli-util')
+cli.raiseErrors = true
+cli.color.enabled = false
+
+let chai = require('chai')
+let chaiAsPromised = require('chai-as-promised')
+
+chai.use(chaiAsPromised)
+
+let nock = require('nock')
+nock.disableNetConnect()

--- a/test/init.js
+++ b/test/init.js
@@ -3,7 +3,6 @@
 
 global.cli = require('heroku-cli-util')
 cli.raiseErrors = true
-cli.color.enabled = false
 
 let chai = require('chai')
 let chaiAsPromised = require('chai-as-promised')

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,3 @@
+--require ./test/helpers.js
+--reporter list
+--recursive

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,3 @@
---require ./test/helpers.js
+--require ./test/init.js
 --reporter list
 --recursive


### PR DESCRIPTION
@cyberdelia and @dickeyxxx could you please review ?  I wanted to update heroku-cli-util but it has been a long time since the library was updated and wanted to make sure I did not break anything since there are some breaking changes in the 5.x series to 6.0.11.  The breaking changes that you should verify that I fixed are as follows.

1) All commands should be wrapped in co.wrap
2) heroku.app() is no longer a method and should call heroku.request or heroku.get directly
3) heroku.post / patch / put no longer take body as the second arg, instead it is an options object

I was afraid I was going to break stuff since there was no test suite, so I wrapped all the commands in tests before I upgraded heroku-cli-util.  I did not fully cover cli.js at this time, I just stubbed the libraries out for now and made sure that the right one is used.

Let me know if you have any questions, it ended up being more code than I expected, since I refactored the addon disambiguation code as well, rather than fixing every instance.  This should be the only small change is that it says `instance` instead of `database` in one command.  I also changed most of the console.log statments to cli.log and process.exit to cli.exit to make things testable.