### PR TITLE
Use new namespace for redis maintenances

### DIFF
--- a/commands/maintenance.js
+++ b/commands/maintenance.js
@@ -29,7 +29,7 @@ module.exports = {
         cli.exit(1, 'Maintenance windows must be "Day HH:MM", where MM is 00 or 30.')
       }
 
-      let maintenance = yield api.request(context, `/client/v11/databases/${addon.name}/maintenance_window`, 'PUT', { description: context.flags.window })
+      let maintenance = yield api.request(context, `/redis/v0/databases/${addon.name}/maintenance_window`, 'PUT', { description: context.flags.window })
       cli.log(`Maintenance window for ${addon.name} (${addon.config_vars.join(', ')}) set to ${maintenance.window}.`)
       cli.exit(0)
     }
@@ -40,12 +40,12 @@ module.exports = {
         cli.exit(1, 'Application must be in maintenance mode or --force flag must be used')
       }
 
-      let maintenance = yield api.request(context, `/client/v11/databases/${addon.name}/maintenance`, 'POST')
+      let maintenance = yield api.request(context, `/redis/v0/databases/${addon.name}/maintenance`, 'POST')
       cli.log(maintenance.message)
       cli.exit(0)
     }
 
-    let maintenance = yield api.request(context, `/client/v11/databases/${addon.name}/maintenance`, 'GET', null)
+    let maintenance = yield api.request(context, `/redis/v0/databases/${addon.name}/maintenance`, 'GET', null)
     cli.log(maintenance.message)
   }))
 }

--- a/test/commands/maintenance.js
+++ b/test/commands/maintenance.js
@@ -25,7 +25,7 @@ describe('heroku redis:maintenance', function () {
       ])
 
     let redis = nock('https://redis-api.heroku.com:443')
-      .get('/client/v11/databases/redis-haiku/maintenance').reply(200, {message: 'Message'})
+      .get('/redis/v0/databases/redis-haiku/maintenance').reply(200, {message: 'Message'})
 
     return command.run({app: 'example', args: {}, flags: {}, auth: {username: 'foobar', password: 'password'}})
     .then(() => app.done())
@@ -41,7 +41,7 @@ describe('heroku redis:maintenance', function () {
       ])
 
     let redis = nock('https://redis-api.heroku.com:443')
-      .put('/client/v11/databases/redis-haiku/maintenance_window', {
+      .put('/redis/v0/databases/redis-haiku/maintenance_window', {
         description: 'Mon 10:00'
       }).reply(200, {window: 'Mon 10:00'})
 
@@ -62,7 +62,7 @@ describe('heroku redis:maintenance', function () {
       .get('/apps/example').reply(200, { maintenance: true })
 
     let redis = nock('https://redis-api.heroku.com:443')
-      .post('/client/v11/databases/redis-haiku/maintenance').reply(200, {message: 'Message'})
+      .post('/redis/v0/databases/redis-haiku/maintenance').reply(200, {message: 'Message'})
 
     return expect(command.run({app: 'example', args: {}, flags: {run: true}, auth: {username: 'foobar', password: 'password'}})).to.be.rejectedWith(exit.ErrorExit)
     .then(() => app.done())


### PR DESCRIPTION
This is ready to ship once we have shipped the PR for the new maintenance endpoints for Redis